### PR TITLE
Allow `workflow_dispatch` GitHub event in `mirror.sh`

### DIFF
--- a/mirror.sh
+++ b/mirror.sh
@@ -18,6 +18,10 @@ elif test "$GITHUB_EVENT_NAME" == "workflow_run"; then
   git remote add mirror ${GITLAB_REPOSITORY}
   git push mirror ${GITHUB_REF}:${GITHUB_REF} --force
   git remote remove mirror
+elif test "$GITHUB_EVENT_NAME" == "workflow_dispatch"; then
+  git remote add mirror ${GITLAB_REPOSITORY}
+  git push mirror ${GITHUB_REF}:${GITHUB_REF} --force
+  git remote remove mirror
 elif test "$GITHUB_EVENT_NAME" == "delete"; then
   if test "$DELETED_REF_TYPE" == "tag"; then
     FULL_DELETED_REF="refs/tags/$DELETED_REF"


### PR DESCRIPTION
`mirror.sh` copies code to GitLab on GitHub `push` and `workflow_run`
events. This adds support for the `workflow_dispatch` event, which
indicates a manual GitHub Action run.

Fixes the "unexpected event" error on manual runs that trigger the `workflow_dispatch` event:

![image](https://user-images.githubusercontent.com/103495/129084470-bbb572b5-af13-4219-9dc8-df023d2c3855.png)

