### PR TITLE
feat: migrate Dockerfile to use Chainguard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
-FROM public.ecr.aws/bitnami/git:2.42.0-debian-11-r43
+FROM 694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/glibc-dynamic:15.1.0-dev AS dev
+USER 0
+RUN apk update && apk add --no-cache bash busybox git ca-certificates
+RUN mkdir -p /out && apk --update-cache --no-cache --root /out --initdb \
+  --keys-dir /etc/apk/keys \
+  --repositories-file /etc/apk/repositories \
+  add bash busybox git ca-certificates
+
+FROM 694713800774.dkr.ecr.us-east-2.amazonaws.com/golden/glibc-dynamic:15.2.0
 
 LABEL "com.github.actions.name"="Mirror to GitLab"
 LABEL "com.github.actions.description"="Mirror branch and tag pushes to GitLab."
 LABEL "com.github.actions.icon"="git-commit"
 LABEL "com.github.actions.color"="blue"
 
+USER 0
+COPY --from=dev /out/ /
 COPY mirror.sh /mirror.sh
 COPY get-password.sh /get-password.sh
+RUN chmod +x /mirror.sh /get-password.sh
+ENV HOME=/home/nonroot
+RUN mkdir -p /home/nonroot && chown -R 65532:65532 /home/nonroot
+USER 65532
 ENTRYPOINT ["/bin/bash", "/mirror.sh"]


### PR DESCRIPTION
This PR migrates the production Dockerfile to use Chainguard images from the private ECR in us-east-2.

What was done:
- Switched base to Chainguard private ECR images only (no public images).
- Implemented multi-stage build:
  - dev stage: golden/glibc-dynamic:15.1.0-dev installs bash, busybox (sh), git, and ca-certificates into a minimal rootfs.
  - final stage: golden/glibc-dynamic:15.2.0 copies the rootfs, adds scripts, sets HOME, uses non-root user 65532, and preserves existing entrypoint behavior.
- Preserved application behavior and entrypoint: ENTRYPOINT ["/bin/bash", "/mirror.sh"].
- Ensured non-root runtime user and executable permissions.
- Optimized image size by copying only necessary artifacts from the dev stage.

Notes:
- No nginx or dagster in this repository; single application Dockerfile only.
- No charts or CI workflows in this repository to update.
- Validated locally:
  - Built image successfully.
  - Simulated push and delete events against a local bare repo; behavior matches current expectations.

Security/Compliance:
- Uses Chainguard images from private ECR 694713800774 in us-east-2.
- Pinned non-latest tags: dev stage 15.1.0-dev, final stage 15.2.0.

